### PR TITLE
Fix public method getCallsRemaining() not returning data.

### DIFF
--- a/src/Shopify.php
+++ b/src/Shopify.php
@@ -291,6 +291,6 @@ class Shopify
             throw new Exception("Call limits can't be polled before a request has been made.");
         }
 
-        return explode('/', $this->last_response_headers['X-Shopify-Shop-Api-Call-Limit']);
+        return explode('/', $this->last_response_headers['X-Shopify-Shop-Api-Call-Limit'][0]);
     }
 }


### PR DESCRIPTION
@LukeTowers getCallsRemaining() fails with PHP Warning `explode() expects parameter 2 to be string, array given`. This is due to `$this->last_response_headers['X-Shopify-Shop-Api-Call-Limit']` on getCallLimitHeaderValue() returning array an not string.
PR is to select the first element of that array, which is the string we're looking for with format "<callsMade>/<callsLimit>". That will feed properly the explode() function and getCallsRemaining() will return the right value.